### PR TITLE
fix: update celery constraint to fix make upgrade

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ~~~~~~~~~~
 *
 
+[1.2.1] - 2022-01-24
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Updated celery constraint to <6.0 to fix make upgrade failure in edx-platform
+
 [1.2.0] - 2022-01-19
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Removed Django22, 30, 31 support

--- a/celery_utils/__init__.py
+++ b/celery_utils/__init__.py
@@ -2,6 +2,6 @@
 Code to support working with celery.
 """
 
-__version__ = '1.2.0'
+__version__ = '1.2.1'
 
 default_app_config = 'celery_utils.apps.CeleryUtilsConfig'  # pylint: disable=invalid-name

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,17 +6,16 @@
 #
 amqp==5.0.9
     # via kombu
-asgiref==3.4.1
+asgiref==3.5.0
     # via django
 billiard==3.6.4.0
     # via celery
-celery==5.0.4
+celery==5.2.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-click==7.1.2
+click==8.0.3
     # via
-    #   -c requirements/constraints.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -58,3 +57,6 @@ vine==5.0.0
     #   kombu
 wcwidth==0.2.5
     # via prompt-toolkit
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/celery50.txt
+++ b/requirements/celery50.txt
@@ -1,7 +1,7 @@
 amqp==5.0.9
 billiard==3.6.4.0
-celery==5.0.4
-click==7.1.2
+celery==5.2.3
+click==8.0.3
 click-didyoumean==0.3.0
 click-repl==0.2.0
 kombu==5.2.3

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -28,7 +28,7 @@ pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via packaging
 requests==2.27.1
     # via codecov

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,6 +13,3 @@
 
 # pinning it to latest release.
 celery<6.0
-
-# celery requires click<8.0 (can be removed when https://github.com/celery/celery/issues/6753 is done).
- click<8.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -12,7 +12,7 @@
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
 
 # pinning it to latest release.
-celery==5.0.4
+celery<6.0
 
 # celery requires click<8.0 (can be removed when https://github.com/celery/celery/issues/6753 is done).
  click<8.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-asgiref==3.4.1
+asgiref==3.5.0
     # via django
 astroid==2.9.3
     # via
@@ -20,9 +20,8 @@ chardet==4.0.0
     # via diff-cover
 charset-normalizer==2.0.10
     # via requests
-click==7.1.2
+click==8.0.3
     # via
-    #   -c requirements/constraints.txt
     #   click-log
     #   code-annotations
     #   edx-lint
@@ -131,7 +130,7 @@ pylint-plugin-utils==0.7
     # via
     #   pylint-celery
     #   pylint-django
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via packaging
 python-slugify==5.0.2
     # via code-annotations

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,7 +8,7 @@ alabaster==0.7.12
     # via sphinx
 amqp==5.0.9
     # via kombu
-asgiref==3.4.1
+asgiref==3.5.0
     # via django
 babel==2.9.1
     # via sphinx
@@ -16,7 +16,7 @@ billiard==3.6.4.0
     # via celery
 bleach==4.1.0
     # via readme-renderer
-celery==5.0.4
+celery==5.2.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
@@ -24,9 +24,8 @@ certifi==2021.10.8
     # via requests
 charset-normalizer==2.0.10
     # via requests
-click==7.1.2
+click==8.0.3
     # via
-    #   -c requirements/constraints.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -86,7 +85,7 @@ pygments==2.11.2
     #   doc8
     #   readme-renderer
     #   sphinx
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via packaging
 pytz==2021.3
     # via
@@ -143,3 +142,6 @@ webencodings==0.5.1
     # via bleach
 zipp==3.7.0
     # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,9 +8,8 @@ astroid==2.9.3
     # via
     #   pylint
     #   pylint-celery
-click==7.1.2
+click==8.0.3
     # via
-    #   -c requirements/constraints.txt
     #   click-log
     #   code-annotations
     #   edx-lint

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
     # via kombu
-asgiref==3.4.1
+asgiref==3.5.0
     # via django
 attrs==21.4.0
     # via pytest
@@ -13,9 +13,8 @@ attrs==21.4.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-click==7.1.2
+click==8.0.3
     # via
-    #   -c requirements/constraints.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -56,7 +55,7 @@ prompt-toolkit==3.0.24
     # via click-repl
 py==1.11.0
     # via pytest
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via packaging
 pytest==6.2.5
     # via
@@ -91,3 +90,6 @@ tomli==2.0.0
     #   kombu
 wcwidth==0.2.5
     # via prompt-toolkit
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools


### PR DESCRIPTION
**Description:** Celery is currently pinned to ==5.0.04 which is causing make upgrade issues in edx-platform, so changing that constraint to <6.0
