### PR TITLE
fix: install pip and pip-tools in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,19 @@ docs: ## generate Sphinx HTML documentation, including API docs
 	tox -e docs
 	$(BROWSER) docs/_build/html/index.html
 
+COMMON_CONSTRAINTS_TXT=requirements/common_constraints.txt
+.PHONY: $(COMMON_CONSTRAINTS_TXT)
+$(COMMON_CONSTRAINTS_TXT):
+	wget -O "$(@)" https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt || touch "$(@)"
+
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
-upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
+upgrade: $(COMMON_CONSTRAINTS_TXT)
+	## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	pip install -q pip-tools
-	pip-compile --upgrade --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
+	pip-compile --upgrade  --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
+	pip-compile --rebuild  --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip-tools.txt
 	pip-compile --rebuild  --upgrade -o requirements/base.txt requirements/base.in
 	pip-compile --rebuild  --upgrade -o requirements/dev.txt requirements/dev.in requirements/quality.in
 	pip-compile --rebuild  --upgrade -o requirements/doc.txt requirements/base.in requirements/doc.in

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ $(COMMON_CONSTRAINTS_TXT):
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: $(COMMON_CONSTRAINTS_TXT)
 	## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
-	pip install -q pip-tools
+	pip install -qr requirements/pip-tools.txt
 	pip-compile --upgrade  --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
 	pip-compile --rebuild  --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
 	pip install -qr requirements/pip.txt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,7 +28,7 @@ click-repl==0.2.0
     # via celery
 django==3.2.13
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
     #   django-model-utils
     #   jsonfield

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via requests
 charset-normalizer==2.0.12
     # via requests
@@ -30,7 +30,7 @@ py==1.11.0
     # via tox
 pyparsing==3.0.9
     # via packaging
-requests==2.27.1
+requests==2.28.0
     # via codecov
 six==1.16.0
     # via

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -1,0 +1,25 @@
+# A central location for most common version constraints
+# (across edx repos) for pip-installation.
+#
+# Similar to other constraint files this file doesn't install any packages.
+# It specifies version constraints that will be applied if a package is needed.
+# When pinning something here, please provide an explanation of why it is a good
+# idea to pin this package across all edx repos, Ideally, link to other information
+# that will help people in the future to remove the pin when possible.
+# Writing an issue against the offending project and linking to it here is good.
+#
+# Note: Changes to this file will automatically be used by other repos, referencing
+#  this file from Github directly. It does not require packaging in edx-lint.
+
+
+# using LTS django version
+Django<4.0
+
+# elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
+# elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
+elasticsearch<7.14.0
+
+setuptools<60
+
+# django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
+django-simple-history==3.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -9,7 +9,7 @@
 # linking to it here is good.
 
 # This file contains all common constraints for edx-repos
--c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+-c common_constraints.txt
 
 # pinning it to latest release.
 celery<6.0

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -5,7 +5,6 @@
 diff-cover                # Changeset diff test coverage
 edx-i18n-tools            # For i18n_tool dummy
 edx-lint                  # For updating pylintrc
-pip-tools                 # Requirements file management
 tox                       # virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes
 twine                     # Utility for PyPI package uploads

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,16 +6,14 @@
 #
 asgiref==3.5.2
     # via django
-astroid==2.11.5
+astroid==2.11.6
     # via
     #   pylint
     #   pylint-celery
 bleach==5.0.0
     # via readme-renderer
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via requests
-cffi==1.15.0
-    # via cryptography
 chardet==4.0.0
     # via diff-cover
 charset-normalizer==2.0.12
@@ -32,8 +30,6 @@ code-annotations==1.3.0
     # via edx-lint
 commonmark==0.9.1
     # via rich
-cryptography==37.0.2
-    # via secretstorage
 diff-cover==6.5.0
     # via -r requirements/dev.in
 dill==0.3.5.1
@@ -42,13 +38,13 @@ distlib==0.3.4
     # via virtualenv
 django==3.2.13
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   edx-i18n-tools
 docutils==0.18.1
     # via readme-renderer
 edx-i18n-tools==0.9.1
     # via -r requirements/dev.in
-edx-lint==5.2.2
+edx-lint==5.2.4
     # via
     #   -r requirements/dev.in
     #   -r requirements/quality.in
@@ -66,10 +62,6 @@ isort==5.10.1
     # via
     #   -r requirements/quality.in
     #   pylint
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   code-annotations
@@ -108,8 +100,6 @@ py==1.11.0
     # via tox
 pycodestyle==2.8.0
     # via -r requirements/quality.in
-pycparser==2.21
-    # via cffi
 pydocstyle==3.0.0
     # via -r requirements/quality.in
 pygments==2.12.0
@@ -117,7 +107,7 @@ pygments==2.12.0
     #   diff-cover
     #   readme-renderer
     #   rich
-pylint==2.14.1
+pylint==2.14.3
     # via
     #   edx-lint
     #   pylint-celery
@@ -143,7 +133,7 @@ pyyaml==6.0
     #   edx-i18n-tools
 readme-renderer==35.0
     # via twine
-requests==2.27.1
+requests==2.28.0
     # via
     #   requests-toolbelt
     #   twine
@@ -153,8 +143,6 @@ rfc3986==2.0.0
     # via twine
 rich==12.4.4
     # via twine
-secretstorage==3.3.2
-    # via keyring
 six==1.16.0
     # via
     #   bleach

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -23,7 +23,6 @@ click==8.1.3
     #   click-log
     #   code-annotations
     #   edx-lint
-    #   pip-tools
 click-log==0.4.0
     # via edx-lint
 code-annotations==1.3.0
@@ -80,10 +79,6 @@ path==16.4.0
     # via edx-i18n-tools
 pbr==5.9.0
     # via stevedore
-pep517==0.12.0
-    # via pip-tools
-pip-tools==6.6.2
-    # via -r requirements/dev.in
 pkginfo==1.8.3
     # via twine
 platformdirs==2.5.2
@@ -161,9 +156,7 @@ text-unidecode==1.3
 toml==0.10.2
     # via tox
 tomli==2.0.1
-    # via
-    #   pep517
-    #   pylint
+    # via pylint
 tomlkit==0.11.0
     # via pylint
 tox==3.25.0
@@ -188,14 +181,11 @@ virtualenv==20.14.1
 webencodings==0.5.1
     # via bleach
 wheel==0.37.1
-    # via
-    #   -r requirements/dev.in
-    #   pip-tools
+    # via -r requirements/dev.in
 wrapt==1.14.1
     # via astroid
 zipp==3.8.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# pip
 # setuptools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -10,7 +10,7 @@ amqp==5.1.1
     # via kombu
 asgiref==3.5.2
     # via django
-babel==2.10.1
+babel==2.10.3
     # via sphinx
 billiard==3.6.4.0
     # via celery
@@ -22,10 +22,8 @@ celery==5.2.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via requests
-cffi==1.15.0
-    # via cryptography
 charset-normalizer==2.0.12
     # via requests
 click==8.1.3
@@ -42,11 +40,9 @@ click-repl==0.2.0
     # via celery
 commonmark==0.9.1
     # via rich
-cryptography==37.0.2
-    # via secretstorage
 django==3.2.13
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
     #   django-model-utils
     #   jsonfield
@@ -73,10 +69,6 @@ importlib-metadata==4.11.4
     #   keyring
     #   sphinx
     #   twine
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via sphinx
 jsonfield==3.1.0
@@ -101,8 +93,6 @@ pockets==0.9.1
     # via sphinxcontrib-napoleon
 prompt-toolkit==3.0.29
     # via click-repl
-pycparser==2.21
-    # via cffi
 pygments==2.12.0
     # via
     #   doc8
@@ -118,7 +108,7 @@ pytz==2022.1
     #   django
 readme-renderer==35.0
     # via twine
-requests==2.27.1
+requests==2.28.0
     # via
     #   requests-toolbelt
     #   sphinx
@@ -131,8 +121,6 @@ rfc3986==2.0.0
     # via twine
 rich==12.4.4
     # via twine
-secretstorage==3.3.2
-    # via keyring
 six==1.16.0
     # via
     #   bleach
@@ -142,7 +130,7 @@ six==1.16.0
     #   sphinxcontrib-napoleon
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.0.1
+sphinx==5.0.2
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme

--- a/requirements/pip-tools.in
+++ b/requirements/pip-tools.in
@@ -1,0 +1,3 @@
+-c constraints.txt
+
+pip-tools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,13 +4,17 @@
 #
 #    make upgrade
 #
+click==8.1.3
+    # via pip-tools
+pep517==0.12.0
+    # via pip-tools
+pip-tools==6.6.2
+    # via -r requirements/pip-tools.in
+tomli==2.0.1
+    # via pep517
 wheel==0.37.1
-    # via -r requirements/pip.in
+    # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.1.2
-    # via -r requirements/pip.in
-setuptools==59.8.0
-    # via
-    #   -c requirements/common_constraints.txt
-    #   -r requirements/pip.in
+# pip
+# setuptools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-astroid==2.11.5
+astroid==2.11.6
     # via
     #   pylint
     #   pylint-celery
@@ -19,7 +19,7 @@ code-annotations==1.3.0
     # via edx-lint
 dill==0.3.5.1
     # via pylint
-edx-lint==5.2.2
+edx-lint==5.2.4
     # via -r requirements/quality.in
 isort==5.10.1
     # via
@@ -41,7 +41,7 @@ pycodestyle==2.8.0
     # via -r requirements/quality.in
 pydocstyle==3.0.0
     # via -r requirements/quality.in
-pylint==2.14.1
+pylint==2.14.3
     # via
     #   edx-lint
     #   pylint-celery

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -30,7 +30,7 @@ coverage[toml]==6.4.1
 ddt==1.5.0
     # via -r requirements/test.in
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
     #   django-model-utils
     #   jsonfield


### PR DESCRIPTION
Added pip-tools requirements file and updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions. For reference, look at this https://github.com/https://github.com/openedx/edx-repo-health/pull/271 for new check added in edx-repo-health.