### PR TITLE
build: Removed future package dependency.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ~~~~~~~~~~
 *
 
+[1.2.2] - 2022-01-24
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Removed future package dependency.
+
 [1.2.1] - 2022-01-24
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Updated celery constraint to <6.0 to fix make upgrade failure in edx-platform

--- a/celery_utils/__init__.py
+++ b/celery_utils/__init__.py
@@ -2,6 +2,6 @@
 Code to support working with celery.
 """
 
-__version__ = '1.2.1'
+__version__ = '1.2.2'
 
 default_app_config = 'celery_utils.apps.CeleryUtilsConfig'  # pylint: disable=invalid-name

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,7 +2,6 @@
 
 -c constraints.txt
 
-future
 celery
 Django >= 1.11
 django-model-utils

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -34,15 +34,13 @@ django==3.2.16
     #   jsonfield
 django-model-utils==4.3.1
     # via -r requirements/base.in
-future==0.18.2
-    # via -r requirements/base.in
 jsonfield==3.1.0
     # via -r requirements/base.in
 kombu==5.2.4
     # via celery
 prompt-toolkit==3.0.36
     # via click-repl
-pytz==2022.7
+pytz==2022.7.1
     # via
     #   celery
     #   django
@@ -55,5 +53,5 @@ vine==5.0.0
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.5
+wcwidth==0.2.6
     # via prompt-toolkit

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,7 +6,7 @@
 #
 certifi==2022.12.7
     # via requests
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
@@ -28,7 +28,7 @@ pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.1
+requests==2.28.2
     # via codecov
 six==1.16.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,7 +18,7 @@ cffi==1.15.1
     # via cryptography
 chardet==5.1.0
     # via diff-cover
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via requests
 click==8.1.3
     # via
@@ -33,7 +33,7 @@ commonmark==0.9.1
     # via rich
 cryptography==39.0.0
     # via secretstorage
-diff-cover==7.3.0
+diff-cover==7.3.2
     # via -r requirements/dev.in
 dill==0.3.6
     # via pylint
@@ -81,7 +81,7 @@ keyring==23.13.1
     # via twine
 lazy-object-proxy==1.9.0
     # via astroid
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via jinja2
 mccabe==0.7.0
     # via pylint
@@ -134,7 +134,7 @@ pylint-plugin-utils==0.7
     #   pylint-django
 python-slugify==7.0.0
     # via code-annotations
-pytz==2022.7
+pytz==2022.7.1
     # via django
 pyyaml==6.0
     # via
@@ -142,7 +142,7 @@ pyyaml==6.0
     #   edx-i18n-tools
 readme-renderer==37.3
     # via twine
-requests==2.28.1
+requests==2.28.2
     # via
     #   requests-toolbelt
     #   twine
@@ -150,7 +150,7 @@ requests-toolbelt==0.10.1
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==13.0.1
+rich==13.1.0
     # via twine
 secretstorage==3.3.3
     # via keyring

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-alabaster==0.7.12
+alabaster==0.7.13
     # via sphinx
 amqp==5.1.1
     # via kombu
@@ -26,7 +26,7 @@ certifi==2022.12.7
     # via requests
 cffi==1.15.1
     # via cryptography
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via requests
 click==8.1.3
     # via
@@ -60,10 +60,8 @@ docutils==0.19
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
-edx-sphinx-theme==3.0.0
+edx-sphinx-theme==3.1.0
     # via -r requirements/doc.in
-future==0.18.2
-    # via -r requirements/base.in
 idna==3.4
     # via requests
 imagesize==1.4.1
@@ -89,7 +87,7 @@ keyring==23.13.1
     # via twine
 kombu==5.2.4
     # via celery
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via jinja2
 more-itertools==9.0.0
     # via jaraco-classes
@@ -115,14 +113,14 @@ pygments==2.14.0
     #   sphinx
 pyproject-hooks==1.0.0
     # via build
-pytz==2022.7
+pytz==2022.7.1
     # via
     #   babel
     #   celery
     #   django
 readme-renderer==37.3
     # via twine
-requests==2.28.1
+requests==2.28.2
     # via
     #   requests-toolbelt
     #   sphinx
@@ -133,7 +131,7 @@ restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==13.0.1
+rich==13.1.0
     # via twine
 secretstorage==3.3.3
     # via keyring
@@ -187,7 +185,7 @@ vine==5.0.0
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.5
+wcwidth==0.2.6
     # via prompt-toolkit
 webencodings==0.5.1
     # via bleach

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -29,7 +29,7 @@ jinja2==3.1.2
     # via code-annotations
 lazy-object-proxy==1.9.0
     # via astroid
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via jinja2
 mccabe==0.7.0
     # via pylint

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -40,8 +40,6 @@ exceptiongroup==1.1.0
     # via pytest
 freezegun==1.2.2
     # via -r requirements/test.in
-future==0.18.2
-    # via -r requirements/base.in
 iniconfig==2.0.0
     # via pytest
 jsonfield==3.1.0
@@ -55,7 +53,7 @@ pluggy==1.0.0
     # via pytest
 prompt-toolkit==3.0.36
     # via click-repl
-pytest==7.2.0
+pytest==7.2.1
     # via
     #   pytest-cov
     #   pytest-django
@@ -67,7 +65,7 @@ python-dateutil==2.8.2
     # via freezegun
 python-memcached==1.59
     # via -r requirements/test.in
-pytz==2022.7
+pytz==2022.7.1
     # via
     #   celery
     #   django
@@ -86,5 +84,5 @@ tomli==2.0.1
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.5
+wcwidth==0.2.6
     # via prompt-toolkit


### PR DESCRIPTION
Details can be found here https://github.com/openedx/edx-celeryutils/issues/170


This packages was added while implementing `ChordableDjangoBackend` in this [PR](https://github.com/openedx/edx-celeryutils/pull/5).

But `ChordableDjangoBackend` removed later in this [PR](https://github.com/openedx/edx-celeryutils/pull/25) but did't remove the dependency.

I think its safe to remove `future` from this repo.