### PR TITLE
fix: remove codecov from requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -40,7 +40,7 @@ kombu==5.2.4
     # via celery
 prompt-toolkit==3.0.38
     # via click-repl
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   celery
     #   django

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -2,6 +2,5 @@
 
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,32 +4,20 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
-    # via requests
-charset-normalizer==3.1.0
-    # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
-coverage==7.2.1
-    # via codecov
 distlib==0.3.6
     # via virtualenv
-filelock==3.10.0
+filelock==3.11.0
     # via
     #   tox
     #   virtualenv
-idna==3.4
-    # via requests
-packaging==23.0
+packaging==23.1
     # via tox
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.2
-    # via codecov
 six==1.16.0
     # via tox
 tomli==2.0.1
@@ -41,7 +29,5 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-urllib3==1.26.15
-    # via requests
 virtualenv==20.21.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.6.0
     # via django
-astroid==2.15.0
+astroid==2.15.2
     # via
     #   pylint
     #   pylint-celery
@@ -14,8 +14,6 @@ bleach==6.0.0
     # via readme-renderer
 certifi==2022.12.7
     # via requests
-cffi==1.15.1
-    # via cryptography
 chardet==5.1.0
     # via diff-cover
 charset-normalizer==3.1.0
@@ -29,8 +27,6 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==1.3.0
     # via edx-lint
-cryptography==39.0.2
-    # via secretstorage
 diff-cover==7.5.0
     # via -r requirements/dev.in
 dill==0.3.6
@@ -49,13 +45,13 @@ edx-lint==5.3.4
     # via
     #   -r requirements/dev.in
     #   -r requirements/quality.in
-filelock==3.10.0
+filelock==3.11.0
     # via
     #   tox
     #   virtualenv
 idna==3.4
     # via requests
-importlib-metadata==6.0.0
+importlib-metadata==6.3.0
     # via
     #   keyring
     #   twine
@@ -67,10 +63,6 @@ isort==5.12.0
     #   pylint
 jaraco-classes==3.2.3
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   code-annotations
@@ -89,7 +81,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==9.1.0
     # via jaraco-classes
-packaging==23.0
+packaging==23.1
     # via tox
 path==16.6.0
     # via edx-i18n-tools
@@ -97,7 +89,7 @@ pbr==5.11.1
     # via stevedore
 pkginfo==1.9.6
     # via twine
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via
     #   pylint
     #   virtualenv
@@ -111,16 +103,14 @@ py==1.11.0
     # via tox
 pycodestyle==2.10.0
     # via -r requirements/quality.in
-pycparser==2.21
-    # via cffi
 pydocstyle==3.0.0
     # via -r requirements/quality.in
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   diff-cover
     #   readme-renderer
     #   rich
-pylint==2.17.0
+pylint==2.17.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -136,7 +126,7 @@ pylint-plugin-utils==0.7
     #   pylint-django
 python-slugify==8.0.1
     # via code-annotations
-pytz==2022.7.1
+pytz==2023.3
     # via django
 pyyaml==6.0
     # via
@@ -152,10 +142,8 @@ requests-toolbelt==0.10.1
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.2
+rich==13.3.4
     # via twine
-secretstorage==3.3.3
-    # via keyring
 six==1.16.0
     # via
     #   bleach
@@ -174,7 +162,7 @@ tomli==2.0.1
     # via
     #   pylint
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via pylint
 tox==3.28.0
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -24,8 +24,6 @@ celery==5.2.7
     #   -r requirements/base.in
 certifi==2022.12.7
     # via requests
-cffi==1.15.1
-    # via cryptography
 charset-normalizer==3.1.0
     # via requests
 click==8.1.3
@@ -40,8 +38,6 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
-cryptography==39.0.2
-    # via secretstorage
 django==3.2.18
     # via
     #   -c requirements/common_constraints.txt
@@ -64,7 +60,7 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==6.3.0
     # via
     #   keyring
     #   sphinx
@@ -73,10 +69,6 @@ importlib-resources==5.12.0
     # via keyring
 jaraco-classes==3.2.3
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via sphinx
 jsonfield==3.1.0
@@ -93,7 +85,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==9.1.0
     # via jaraco-classes
-packaging==23.0
+packaging==23.1
     # via
     #   build
     #   sphinx
@@ -105,9 +97,7 @@ pockets==0.9.1
     # via sphinxcontrib-napoleon
 prompt-toolkit==3.0.38
     # via click-repl
-pycparser==2.21
-    # via cffi
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   doc8
     #   readme-renderer
@@ -115,7 +105,7 @@ pygments==2.14.0
     #   sphinx
 pyproject-hooks==1.0.0
     # via build
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   babel
     #   celery
@@ -133,10 +123,8 @@ restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==13.3.2
+rich==13.3.4
     # via twine
-secretstorage==3.3.3
-    # via keyring
 six==1.16.0
     # via
     #   bleach

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,9 +8,9 @@ build==0.10.0
     # via pip-tools
 click==8.1.3
     # via pip-tools
-packaging==23.0
+packaging==23.1
     # via build
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via build

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.40.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.0.1
     # via -r requirements/pip.in
-setuptools==67.6.0
+setuptools==67.6.1
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-astroid==2.15.0
+astroid==2.15.2
     # via
     #   pylint
     #   pylint-celery
@@ -35,13 +35,13 @@ mccabe==0.7.0
     # via pylint
 pbr==5.11.1
     # via stevedore
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via pylint
 pycodestyle==2.10.0
     # via -r requirements/quality.in
 pydocstyle==3.0.0
     # via -r requirements/quality.in
-pylint==2.17.0
+pylint==2.17.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -71,7 +71,7 @@ text-unidecode==1.3
     # via python-slugify
 tomli==2.0.1
     # via pylint
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via pylint
 typing-extensions==4.5.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,8 +7,6 @@
     # via kombu
 asgiref==3.6.0
     # via django
-attrs==22.2.0
-    # via pytest
     # via celery
     # via
     #   -c requirements/constraints.txt
@@ -25,7 +23,7 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
-coverage[toml]==7.2.1
+coverage[toml]==7.2.3
     # via pytest-cov
 ddt==1.6.0
     # via -r requirements/test.in
@@ -47,13 +45,13 @@ jsonfield==3.1.0
     # via celery
 mock==5.0.1
     # via -r requirements/test.in
-packaging==23.0
+packaging==23.1
     # via pytest
 pluggy==1.0.0
     # via pytest
 prompt-toolkit==3.0.38
     # via click-repl
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   pytest-cov
     #   pytest-django
@@ -65,7 +63,7 @@ python-dateutil==2.8.2
     # via freezegun
 python-memcached==1.59
     # via -r requirements/test.in
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   celery
     #   django


### PR DESCRIPTION
### Description
- Codecov deprecated the pypi package long ago (Feb 2022) but left it up until now.
- Removing the package from requirements to fix the failing upgrade job.
- The Github Action we use to upload to codecov doesn’t depend on the package so our CI coverage won’t be affected by the change.